### PR TITLE
Function args are now keyed, easier to use

### DIFF
--- a/tpfd/rules.py
+++ b/tpfd/rules.py
@@ -34,10 +34,11 @@ class RuleMap(defaultdict):
                     if self.debug:
                         logging.debug(i['parse_resp'].named)
                         logging.debug(func)
-                    return func(i['parse_resp'].named)
+                    return func(**i['parse_resp'].named)
 
         except KeyError as error:
             logging.debug("Rule '{0} not found or matched.'".format(error))
+
 
 class Rule(object):
     pass


### PR DESCRIPTION
You can now use your functions like so

```python

@p.on_recognize('The {noun} who say {thing}!')
def two_word_test(thing, noun):  # Order of the keys do not matter
    return (noun, thing)

pprint(p.parse_string('The knights who say Ni!'))
```